### PR TITLE
Creating all standard HTML elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,10 @@ const h2 = Bouture.h2('subheading');
 // append to actual DOM
 document.body.append(h1.getElement());
 ````
+
+## Cross-cutting concerns
+
+- Any usage that is not documented should throw or return undefined
+- Browser compatibility: Edge
+
+

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ const div = Bouture.div;
 
 // With text
 const h1 = Bouture.h1('Best lib of all times');
-const h2 = Bouture.h2('subheading');
+const h2 = Bouture.h2('subheading'); 
 
 // Attribute
 //const input = Bouture.input({type: 'tel'});

--- a/bouture.js
+++ b/bouture.js
@@ -1,14 +1,19 @@
+const Bouture = {}
 
-export default {
-  get div () {
-    const div = document.createElement('div')
-    function branche (text) {
-      div.append(text)
+;['h1', 'h2', 'a', 'input', 'iframe', 'img', 'div'].forEach(name => {
+  Object.defineProperty(Bouture, name, {
+    get: () => {
+      const element = document.createElement(name)
+      function branche (text) {
+        element.append(text)
+        return branche
+      }
+      branche.getElement = () => {
+        return element
+      }
       return branche
     }
-    branche.getElement = () => {
-      return div
-    }
-    return branche
-  }
-}
+  })
+})
+
+export default Bouture

--- a/bouture.js
+++ b/bouture.js
@@ -1,9 +1,10 @@
 const Bouture = {}
+const tags = ['a', 'abbr', 'address', 'area', 'article', 'aside', 'audio', 'b', 'base', 'bdi', 'bdo', 'blockquote', 'body', 'br', 'button', 'canvas', 'caption', 'cite', 'code', 'col', 'colgroup', 'data', 'datalist', 'dd', 'del', 'details', 'dfn', 'dialog', 'div', 'dl', 'dt', 'em', 'embed', 'fieldset', 'figcaption', 'figure', 'footer', 'form', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'head', 'header', 'hgroup', 'hr', 'html', 'i', 'iframe', 'img', 'input', 'ins', 'kbd', 'label', 'legend', 'li', 'link', 'main', 'map', 'mark', 'meta', 'meter', 'nav', 'noscript', 'object', 'ol', 'optgroup', 'option', 'output', 'p', 'param', 'picture', 'pre', 'progress', 'q', 'rp', 'rt', 'rtc', 'ruby', 's', 'samp', 'script', 'section', 'select', 'slot', 'small', 'source', 'span', 'strong', 'style', 'sub', 'summary', 'sup', 'table', 'tbody', 'td', 'template', 'textarea', 'tfoot', 'th', 'thead', 'time', 'title', 'tr', 'track', 'u', 'ul', 'var', 'video', 'wbr']
 
-;['h1', 'h2', 'a', 'input', 'iframe', 'img', 'div'].forEach(name => {
-  Object.defineProperty(Bouture, name, {
+tags.forEach(tag => {
+  Object.defineProperty(Bouture, tag, {
     get: () => {
-      const element = document.createElement(name)
+      const element = document.createElement(tag)
       function branche (text) {
         element.append(text)
         return branche

--- a/test/bouture.test.js
+++ b/test/bouture.test.js
@@ -28,3 +28,27 @@ describe(`Bouture.div('yo')`, () => {
     expect(bdiv.getElement().textContent).to.equal('yo')
   })
 })
+
+describe('Bouture.a', () => {
+  it('should create a <a>', () => {
+    const a = Bouture.a
+
+    expect(a.getElement()).to.be.an.instanceof(HTMLAnchorElement)
+  })
+})
+
+describe('Bouture.h1', () => {
+  it('should create a <h1>', () => {
+    const h1 = Bouture.h1
+
+    expect(h1.getElement()).to.be.an.instanceof(HTMLHeadingElement)
+  })
+})
+
+describe('Bouture.bloublou', () => {
+  it('should return undefined', () => {
+    const bloublou = Bouture.bloublou
+
+    expect(bloublou).to.be.undefined
+  })
+})


### PR DESCRIPTION
- [x] must enable creating all standard HTML elements (without obsolete or deprecated)
- [x] must return `undefined` for `Bouture.bloublou`

Note: 
- Elements list provides from:  [MDB](https://developer.mozilla.org/en-US/docs/Web/HTML/Element)