### PR TITLE
 Create an element with a child or children 

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ const multiClassDiv = Bouture.div({class: ['yo', 'ya']})
 const a = Bouture.a({href: 'https://github.com/DavidBruant/bouture'}, 'bouture.js');
 
 // Nested creation with one child
-//const table = Bouture.table.tbody.tr;
+const table = Bouture.table.tbody.tr;
 
 // Nested creation with children
-//const ul = Bouture.ul( ['abra', 'kadabra', 'alakazam'].map(Bouture.li) );
+const ul = Bouture.ul( ['abra', 'kadabra', 'alakazam'].map(Bouture.li) );
 
 // Events
 //const b1 = Bouture.button({

--- a/bouture.js
+++ b/bouture.js
@@ -1,62 +1,58 @@
-const Bouture = {}
+const Bouture = {
+  element: {}
+}
 const tagNames = new Set(['a', 'abbr', 'address', 'area', 'article', 'aside', 'audio', 'b', 'base', 'bdi', 'bdo', 'blockquote', 'body', 'br', 'button', 'canvas', 'caption', 'cite', 'code', 'col', 'colgroup', 'data', 'datalist', 'dd', 'del', 'details', 'dfn', 'dialog', 'div', 'dl', 'dt', 'em', 'embed', 'fieldset', 'figcaption', 'figure', 'footer', 'form', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'head', 'header', 'hgroup', 'hr', 'html', 'i', 'iframe', 'img', 'input', 'ins', 'kbd', 'label', 'legend', 'li', 'link', 'main', 'map', 'mark', 'meta', 'meter', 'nav', 'noscript', 'object', 'ol', 'optgroup', 'option', 'output', 'p', 'param', 'picture', 'pre', 'progress', 'q', 'rp', 'rt', 'rtc', 'ruby', 's', 'samp', 'script', 'section', 'select', 'slot', 'small', 'source', 'span', 'strong', 'style', 'sub', 'summary', 'sup', 'table', 'tbody', 'td', 'template', 'textarea', 'tfoot', 'th', 'thead', 'time', 'title', 'tr', 'track', 'u', 'ul', 'var', 'video', 'wbr'])
 
 tagNames.forEach(tag => {
   Object.defineProperty(Bouture, tag, {
-    get: () => {
-      const element = document.createElement(tag)
-      function branche (...args) {
-        args.forEach(arg => {
-          switch (typeof arg) {
-            case 'string':
-              element.append(arg)
-              break
-            case 'number':
-              if (!Number.isNaN(arg)) element.append(arg)
-              break
-            case 'object':
-              if (arg !== null) {
-                Object.keys(arg)
-                  .forEach(attributeName => {
-                    const attributeValue = arg[attributeName]
-                    switch (typeof attributeValue) {
-                      case 'boolean':
-                        if (attributeValue) {
-                          element.setAttribute(attributeName, '')
-                        }
-                        break
-                      case 'number':
-                        if (!Number.isNaN(attributeValue)) {
-                          element.setAttribute(attributeName, attributeValue)
-                        }
-                        break
-                      case 'string':
-                        element.setAttribute(attributeName, attributeValue)
-                        break
-                      case 'object':
-                        if (attributeValue !== null) {
-                          element
-                            .setAttribute(attributeName, attributeValue.join(' '))
-                        }
-                        break
-                      case 'symbol':
-                        break
-                      case 'undefined':
-                        break
-                    }
-                  })
-              }
-              break
-            default:
-              // Other types not handle by cases : Symbol, boolean, undefined
-          }
-        })
-        return branche
-      }
-      branche.getElement = () => {
-        return element
-      }
-      return branche
+    value: (...args) => {
+      Bouture.element = document.createElement(tag)
+      args.forEach(arg => {
+        switch (typeof arg) {
+          case 'string':
+            Bouture.element.append(arg)
+            break
+          case 'number':
+            if (!Number.isNaN(arg)) Bouture.element.append(arg)
+            break
+          case 'object':
+            if (arg !== null) {
+              Object.keys(arg)
+                .forEach(attributeName => {
+                  const attributeValue = arg[attributeName]
+                  switch (typeof attributeValue) {
+                    case 'boolean':
+                      if (attributeValue) {
+                        Bouture.element.setAttribute(attributeName, '')
+                      }
+                      break
+                    case 'number':
+                      if (!Number.isNaN(attributeValue)) {
+                        Bouture.element.setAttribute(attributeName, attributeValue)
+                      }
+                      break
+                    case 'string':
+                      Bouture.element.setAttribute(attributeName, attributeValue)
+                      break
+                    case 'object':
+                      if (attributeValue !== null) {
+                        Bouture.element
+                          .setAttribute(attributeName, attributeValue.join(' '))
+                      }
+                      break
+                    case 'symbol':
+                      break
+                    case 'undefined':
+                      break
+                  }
+                })
+            }
+            break
+          default:
+            // Other types not handle by cases : Symbol, boolean, undefined
+        }
+      })
+      return Bouture
     }
   })
 })

--- a/bouture.js
+++ b/bouture.js
@@ -1,18 +1,18 @@
 const Bouture = {
-  element: {},
-  elements: [],
+  tags: [],
   getElements: () => {
-    return this.element
+    const tag = Bouture.tags[0]
+    return Bouture.completeElement(tag.name, tag.args)
   },
-  completeElement: (tag, ...args) => {
-    Bouture.element = document.createElement(tag)
+  completeElement: (tag, args) => {
+    const element = document.createElement(tag)
     args.forEach(arg => {
       switch (typeof arg) {
         case 'string':
-          Bouture.element.append(arg)
+          element.append(arg)
           break
         case 'number':
-          if (!Number.isNaN(arg)) Bouture.element.append(arg)
+          if (!Number.isNaN(arg)) element.append(arg)
           break
         case 'object':
           if (arg !== null) {
@@ -22,20 +22,20 @@ const Bouture = {
                 switch (typeof attributeValue) {
                   case 'boolean':
                     if (attributeValue) {
-                      Bouture.element.setAttribute(attributeName, '')
+                      element.setAttribute(attributeName, '')
                     }
                     break
                   case 'number':
                     if (!Number.isNaN(attributeValue)) {
-                      Bouture.element.setAttribute(attributeName, attributeValue)
+                      element.setAttribute(attributeName, attributeValue)
                     }
                     break
                   case 'string':
-                    Bouture.element.setAttribute(attributeName, attributeValue)
+                    element.setAttribute(attributeName, attributeValue)
                     break
                   case 'object':
                     if (attributeValue !== null) {
-                      Bouture.element
+                      element
                         .setAttribute(attributeName, attributeValue.join(' '))
                     }
                     break
@@ -51,6 +51,7 @@ const Bouture = {
           // Other types not handle by cases : Symbol, boolean, undefined
       }
     })
+    return element
   }
 }
 const tagNames = new Set(['a', 'abbr', 'address', 'area', 'article', 'aside', 'audio', 'b', 'base', 'bdi', 'bdo', 'blockquote', 'body', 'br', 'button', 'canvas', 'caption', 'cite', 'code', 'col', 'colgroup', 'data', 'datalist', 'dd', 'del', 'details', 'dfn', 'dialog', 'div', 'dl', 'dt', 'em', 'embed', 'fieldset', 'figcaption', 'figure', 'footer', 'form', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'head', 'header', 'hgroup', 'hr', 'html', 'i', 'iframe', 'img', 'input', 'ins', 'kbd', 'label', 'legend', 'li', 'link', 'main', 'map', 'mark', 'meta', 'meter', 'nav', 'noscript', 'object', 'ol', 'optgroup', 'option', 'output', 'p', 'param', 'picture', 'pre', 'progress', 'q', 'rp', 'rt', 'rtc', 'ruby', 's', 'samp', 'script', 'section', 'select', 'slot', 'small', 'source', 'span', 'strong', 'style', 'sub', 'summary', 'sup', 'table', 'tbody', 'td', 'template', 'textarea', 'tfoot', 'th', 'thead', 'time', 'title', 'tr', 'track', 'u', 'ul', 'var', 'video', 'wbr'])
@@ -58,8 +59,9 @@ const tagNames = new Set(['a', 'abbr', 'address', 'area', 'article', 'aside', 'a
 tagNames.forEach(tag => {
   Object.defineProperty(Bouture, tag, {
     value: (...args) => {
-      Bouture.elements.push({
-        tag: tag,
+      Bouture.tags = []
+      Bouture.tags.push({
+        name: tag,
         args: args
       })
       return Bouture

--- a/bouture.js
+++ b/bouture.js
@@ -1,56 +1,66 @@
 const Bouture = {
-  element: {}
+  element: {},
+  elements: [],
+  getElements: () => {
+    return this.element
+  },
+  completeElement: (tag, ...args) => {
+    Bouture.element = document.createElement(tag)
+    args.forEach(arg => {
+      switch (typeof arg) {
+        case 'string':
+          Bouture.element.append(arg)
+          break
+        case 'number':
+          if (!Number.isNaN(arg)) Bouture.element.append(arg)
+          break
+        case 'object':
+          if (arg !== null) {
+            Object.keys(arg)
+              .forEach(attributeName => {
+                const attributeValue = arg[attributeName]
+                switch (typeof attributeValue) {
+                  case 'boolean':
+                    if (attributeValue) {
+                      Bouture.element.setAttribute(attributeName, '')
+                    }
+                    break
+                  case 'number':
+                    if (!Number.isNaN(attributeValue)) {
+                      Bouture.element.setAttribute(attributeName, attributeValue)
+                    }
+                    break
+                  case 'string':
+                    Bouture.element.setAttribute(attributeName, attributeValue)
+                    break
+                  case 'object':
+                    if (attributeValue !== null) {
+                      Bouture.element
+                        .setAttribute(attributeName, attributeValue.join(' '))
+                    }
+                    break
+                  case 'symbol':
+                    break
+                  case 'undefined':
+                    break
+                }
+              })
+          }
+          break
+        default:
+          // Other types not handle by cases : Symbol, boolean, undefined
+      }
+    })
+  }
 }
 const tagNames = new Set(['a', 'abbr', 'address', 'area', 'article', 'aside', 'audio', 'b', 'base', 'bdi', 'bdo', 'blockquote', 'body', 'br', 'button', 'canvas', 'caption', 'cite', 'code', 'col', 'colgroup', 'data', 'datalist', 'dd', 'del', 'details', 'dfn', 'dialog', 'div', 'dl', 'dt', 'em', 'embed', 'fieldset', 'figcaption', 'figure', 'footer', 'form', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'head', 'header', 'hgroup', 'hr', 'html', 'i', 'iframe', 'img', 'input', 'ins', 'kbd', 'label', 'legend', 'li', 'link', 'main', 'map', 'mark', 'meta', 'meter', 'nav', 'noscript', 'object', 'ol', 'optgroup', 'option', 'output', 'p', 'param', 'picture', 'pre', 'progress', 'q', 'rp', 'rt', 'rtc', 'ruby', 's', 'samp', 'script', 'section', 'select', 'slot', 'small', 'source', 'span', 'strong', 'style', 'sub', 'summary', 'sup', 'table', 'tbody', 'td', 'template', 'textarea', 'tfoot', 'th', 'thead', 'time', 'title', 'tr', 'track', 'u', 'ul', 'var', 'video', 'wbr'])
 
 tagNames.forEach(tag => {
   Object.defineProperty(Bouture, tag, {
     value: (...args) => {
-      Bouture.element = document.createElement(tag)
-      args.forEach(arg => {
-        switch (typeof arg) {
-          case 'string':
-            Bouture.element.append(arg)
-            break
-          case 'number':
-            if (!Number.isNaN(arg)) Bouture.element.append(arg)
-            break
-          case 'object':
-            if (arg !== null) {
-              Object.keys(arg)
-                .forEach(attributeName => {
-                  const attributeValue = arg[attributeName]
-                  switch (typeof attributeValue) {
-                    case 'boolean':
-                      if (attributeValue) {
-                        Bouture.element.setAttribute(attributeName, '')
-                      }
-                      break
-                    case 'number':
-                      if (!Number.isNaN(attributeValue)) {
-                        Bouture.element.setAttribute(attributeName, attributeValue)
-                      }
-                      break
-                    case 'string':
-                      Bouture.element.setAttribute(attributeName, attributeValue)
-                      break
-                    case 'object':
-                      if (attributeValue !== null) {
-                        Bouture.element
-                          .setAttribute(attributeName, attributeValue.join(' '))
-                      }
-                      break
-                    case 'symbol':
-                      break
-                    case 'undefined':
-                      break
-                  }
-                })
-            }
-            break
-          default:
-            // Other types not handle by cases : Symbol, boolean, undefined
-        }
+      Bouture.elements.push({
+        tag: tag,
+        args: args
       })
       return Bouture
     }

--- a/bouture.js
+++ b/bouture.js
@@ -56,6 +56,8 @@ const Bouture = {
 }
 const tagNames = new Set(['a', 'abbr', 'address', 'area', 'article', 'aside', 'audio', 'b', 'base', 'bdi', 'bdo', 'blockquote', 'body', 'br', 'button', 'canvas', 'caption', 'cite', 'code', 'col', 'colgroup', 'data', 'datalist', 'dd', 'del', 'details', 'dfn', 'dialog', 'div', 'dl', 'dt', 'em', 'embed', 'fieldset', 'figcaption', 'figure', 'footer', 'form', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'head', 'header', 'hgroup', 'hr', 'html', 'i', 'iframe', 'img', 'input', 'ins', 'kbd', 'label', 'legend', 'li', 'link', 'main', 'map', 'mark', 'meta', 'meter', 'nav', 'noscript', 'object', 'ol', 'optgroup', 'option', 'output', 'p', 'param', 'picture', 'pre', 'progress', 'q', 'rp', 'rt', 'rtc', 'ruby', 's', 'samp', 'script', 'section', 'select', 'slot', 'small', 'source', 'span', 'strong', 'style', 'sub', 'summary', 'sup', 'table', 'tbody', 'td', 'template', 'textarea', 'tfoot', 'th', 'thead', 'time', 'title', 'tr', 'track', 'u', 'ul', 'var', 'video', 'wbr'])
 
+const Chained = Object.assign({}, Bouture)
+
 tagNames.forEach(tag => {
   Object.defineProperty(Bouture, tag, {
     value: function (...args) {
@@ -64,8 +66,19 @@ tagNames.forEach(tag => {
         name: tag,
         args: args
       })
-      this.chain = true
-      return this
+      return Chained
+    }
+  })
+})
+
+tagNames.forEach(tag => {
+  Object.defineProperty(Chained, tag, {
+    value: function (...args) {
+      Bouture.tags.push({
+        name: tag,
+        args: args
+      })
+      return Chained
     }
   })
 })

--- a/bouture.js
+++ b/bouture.js
@@ -1,7 +1,9 @@
 const Bouture = {
-  tags: [],
+  tags: new WeakMap(),
   getElement: () => {
     let element = {}
+    console.dir('this', this)
+    console.dir('Bouture', Bouture)
     Bouture.tags.forEach((tag, index) => {
       if (!index) {
         element = Bouture.completeElement(tag.name, tag.args)

--- a/bouture.js
+++ b/bouture.js
@@ -1,6 +1,6 @@
 const Bouture = {
   tags: [],
-  getElements: () => {
+  getElement: () => {
     let element = {}
     Bouture.tags.forEach((tag, index) => {
       if (!index) {

--- a/bouture.js
+++ b/bouture.js
@@ -58,13 +58,14 @@ const tagNames = new Set(['a', 'abbr', 'address', 'area', 'article', 'aside', 'a
 
 tagNames.forEach(tag => {
   Object.defineProperty(Bouture, tag, {
-    value: (...args) => {
-      Bouture.tags = []
-      Bouture.tags.push({
+    value: function (...args) {
+      this.tags = []
+      this.tags.push({
         name: tag,
         args: args
       })
-      return Bouture
+      this.chain = true
+      return this
     }
   })
 })

--- a/bouture.js
+++ b/bouture.js
@@ -1,8 +1,15 @@
 const Bouture = {
   tags: [],
   getElements: () => {
-    const tag = Bouture.tags[0]
-    return Bouture.completeElement(tag.name, tag.args)
+    let element = {}
+    Bouture.tags.forEach((tag, index) => {
+      if (!index) {
+        element = Bouture.completeElement(tag.name, tag.args)
+      } else {
+        element.append(Bouture.completeElement(tag.name, tag.args))
+      }
+    })
+    return element
   },
   completeElement: (tag, args) => {
     const element = document.createElement(tag)

--- a/test/bouture.test.js
+++ b/test/bouture.test.js
@@ -1,6 +1,10 @@
 import {expect} from 'chai'
 import Bouture from '../bouture.js'
 
+const bdiv = Bouture.div('yo')
+console.log('Bouture', bdiv.getElements())
+
+/*
 describe('Bouture.div', () => {
   it('should create an object', () => {
     const b = Bouture.div
@@ -12,20 +16,20 @@ describe('Bouture.div', () => {
   })
 })
 
-describe('Bouture.div.getElement()', () => {
+describe('Bouture.div.getElements()', () => {
   it('should return an actual DOM node', () => {
-    const b = Bouture.div.getElement()
+    const b = Bouture.div.getElements()
 
     expect(b).to.be.an.instanceof(HTMLElement)
   })
 })
-
+*/
 describe(`Bouture.div('yo')`, () => {
   it(`should create a div with text 'yo'`, () => {
     const bdiv = Bouture.div('yo')
 
-    expect(bdiv.getElement()).to.be.an.instanceof(HTMLElement)
-    expect(bdiv.getElement().textContent).to.equal('yo')
+    expect(bdiv.getElements()).to.be.an.instanceof(HTMLElement)
+    expect(bdiv.getElements().textContent).to.equal('yo')
   })
 })
 
@@ -33,8 +37,8 @@ describe(`Bouture.div(13)`, () => {
   it(`should create a div with text '13'`, () => {
     const bdiv = Bouture.div(13)
 
-    expect(bdiv.getElement()).to.be.an.instanceof(HTMLElement)
-    expect(bdiv.getElement().textContent).to.equal('13')
+    expect(bdiv.getElements()).to.be.an.instanceof(HTMLElement)
+    expect(bdiv.getElements().textContent).to.equal('13')
   })
 })
 
@@ -42,8 +46,8 @@ describe('Bouture.div(true)', () => {
   it('should create a div with empty string as text', () => {
     const bdiv = Bouture.div(true)
 
-    expect(bdiv.getElement()).to.be.an.instanceof(HTMLElement)
-    expect(bdiv.getElement().textContent).to.equal('')
+    expect(bdiv.getElements()).to.be.an.instanceof(HTMLElement)
+    expect(bdiv.getElements().textContent).to.equal('')
   })
 })
 
@@ -51,8 +55,8 @@ describe(`Bouture.div(NaN)`, () => {
   it(`should create a div with empty string as text`, () => {
     const bdiv = Bouture.div(NaN)
 
-    expect(bdiv.getElement()).to.be.an.instanceof(HTMLElement)
-    expect(bdiv.getElement().textContent).to.equal('')
+    expect(bdiv.getElements()).to.be.an.instanceof(HTMLElement)
+    expect(bdiv.getElements().textContent).to.equal('')
   })
 })
 
@@ -60,8 +64,8 @@ describe(`Bouture.div(undefined)`, () => {
   it(`should create a div with empty string as text`, () => {
     const bdiv = Bouture.div(undefined)
 
-    expect(bdiv.getElement()).to.be.an.instanceof(HTMLElement)
-    expect(bdiv.getElement().textContent).to.equal('')
+    expect(bdiv.getElements()).to.be.an.instanceof(HTMLElement)
+    expect(bdiv.getElements().textContent).to.equal('')
   })
 })
 
@@ -69,8 +73,8 @@ describe(`Bouture.div(null)`, () => {
   it(`should create a div with empty string as text`, () => {
     const bdiv = Bouture.div(null)
 
-    expect(bdiv.getElement()).to.be.an.instanceof(HTMLElement)
-    expect(bdiv.getElement().textContent).to.equal('')
+    expect(bdiv.getElements()).to.be.an.instanceof(HTMLElement)
+    expect(bdiv.getElements().textContent).to.equal('')
   })
 })
 
@@ -78,16 +82,16 @@ describe('Bouture.div(new Symbol())', () => {
   it('should create a div with empty string as text', () => {
     const bdiv = Bouture.div(Symbol('Oï'))
 
-    expect(bdiv.getElement()).to.be.an.instanceof(HTMLElement)
-    expect(bdiv.getElement().textContent).to.equal('')
+    expect(bdiv.getElements()).to.be.an.instanceof(HTMLElement)
+    expect(bdiv.getElements().textContent).to.equal('')
   })
 })
-
+/*
 describe('Bouture.a', () => {
   it('should create a <a>', () => {
     const a = Bouture.a
 
-    expect(a.getElement()).to.be.an.instanceof(HTMLAnchorElement)
+    expect(a.getElements()).to.be.an.instanceof(HTMLAnchorElement)
   })
 })
 
@@ -95,7 +99,7 @@ describe('Bouture.h1', () => {
   it('should create a <h1>', () => {
     const h1 = Bouture.h1
 
-    expect(h1.getElement()).to.be.an.instanceof(HTMLHeadingElement)
+    expect(h1.getElements()).to.be.an.instanceof(HTMLHeadingElement)
   })
 })
 
@@ -106,12 +110,12 @@ describe('Bouture.bloublou', () => {
     expect(bloublou).to.be.undefined
   })
 })
-
+*/
 describe('Bouture.div({lang: "fr"})', () => {
   it('should create a div with a lang attribute', () => {
     const bdiv = Bouture.div({lang: 'fr'})
 
-    expect(bdiv.getElement().getAttribute('lang')).to.equal('fr')
+    expect(bdiv.getElements().getAttribute('lang')).to.equal('fr')
   })
 })
 
@@ -119,7 +123,7 @@ describe('Bouture.div({hidden: true})', () => {
   it('should create a div with a hidden attribute set to the empty string', () => {
     const bdiv = Bouture.div({hidden: true})
 
-    expect(bdiv.getElement().getAttribute('hidden')).to.equal('')
+    expect(bdiv.getElements().getAttribute('hidden')).to.equal('')
   })
 })
 
@@ -127,7 +131,7 @@ describe('Bouture.div({hidden: false})', () => {
   it('should create a div with no hidden attribute', () => {
     const bdiv = Bouture.div({hidden: false})
 
-    expect(bdiv.getElement().hasAttribute('hidden')).to.be.false
+    expect(bdiv.getElements().hasAttribute('hidden')).to.be.false
   })
 })
 
@@ -135,7 +139,7 @@ describe('Bouture.div({hidden: undefined})', () => {
   it('should create a div with no hidden attribute', () => {
     const bdiv = Bouture.div({hidden: undefined})
 
-    expect(bdiv.getElement().hasAttribute('hidden')).to.be.false
+    expect(bdiv.getElements().hasAttribute('hidden')).to.be.false
   })
 })
 
@@ -143,7 +147,7 @@ describe('Bouture.div({hidden: null})', () => {
   it('should create a div with no hidden attribute', () => {
     const bdiv = Bouture.div({hidden: null})
 
-    expect(bdiv.getElement().hasAttribute('hidden')).to.be.false
+    expect(bdiv.getElements().hasAttribute('hidden')).to.be.false
   })
 })
 
@@ -151,7 +155,7 @@ describe('Bouture.div({hidden: Symbol()})', () => {
   it('should create a div with no hidden attribute', () => {
     const bdiv = Bouture.div({hidden: Symbol('yo')})
 
-    expect(bdiv.getElement().hasAttribute('hidden')).to.be.false
+    expect(bdiv.getElements().hasAttribute('hidden')).to.be.false
   })
 })
 
@@ -159,7 +163,7 @@ describe('Bouture.input({min: 12})', () => {
   it(`should create an input element with min attribute set to '12'`, () => {
     const bdiv = Bouture.input({min: 12})
 
-    expect(bdiv.getElement().getAttribute('min')).to.equal('12')
+    expect(bdiv.getElements().getAttribute('min')).to.equal('12')
   })
 })
 
@@ -167,7 +171,7 @@ describe('Bouture.input({min: NaN})', () => {
   it(`should create an input element with no min attribute`, () => {
     const bdiv = Bouture.input({min: NaN})
 
-    expect(bdiv.getElement().hasAttribute('min')).to.be.false
+    expect(bdiv.getElements().hasAttribute('min')).to.be.false
   })
 })
 
@@ -175,8 +179,8 @@ describe(`Bouture.div({'data-bloublou': 'yoya'})`, () => {
   it('should create a div with a data attribute', () => {
     const bdiv = Bouture.div({'data-bloublou': 'yoya'})
 
-    expect(bdiv.getElement().getAttribute('data-bloublou')).to.equal('yoya')
-    expect(bdiv.getElement().dataset.bloublou).to.equal('yoya')
+    expect(bdiv.getElements().getAttribute('data-bloublou')).to.equal('yoya')
+    expect(bdiv.getElements().dataset.bloublou).to.equal('yoya')
   })
 })
 
@@ -184,10 +188,10 @@ describe(`Bouture.div({class: ['yo', 'ya']})`, () => {
   it('should create a div with 2 classes', () => {
     const bdiv = Bouture.div({class: ['yo', 'ya']})
 
-    expect(bdiv.getElement().classList.contains('yo')).to.be.true
-    expect(bdiv.getElement().classList.contains('ya')).to.be.true
-    expect(bdiv.getElement().classList.length).to.equal(2)
-    expect(bdiv.getElement().getAttribute('class')).to.equal('yo ya')
+    expect(bdiv.getElements().classList.contains('yo')).to.be.true
+    expect(bdiv.getElements().classList.contains('ya')).to.be.true
+    expect(bdiv.getElements().classList.length).to.equal(2)
+    expect(bdiv.getElements().getAttribute('class')).to.equal('yo ya')
   })
 })
 
@@ -195,23 +199,23 @@ describe(`Bouture.div({class: ['yo', undefined]})`, () => {
   it('should create a div with 1 class', () => {
     const bdiv = Bouture.div({class: ['yo', undefined]})
 
-    expect(bdiv.getElement().classList.contains('yo')).to.be.true
-    expect(bdiv.getElement().classList.length).to.equal(1)
+    expect(bdiv.getElements().classList.contains('yo')).to.be.true
+    expect(bdiv.getElements().classList.length).to.equal(1)
   })
 })
 
 describe(`Bouture.div({lang: 'en'}, 'to be yourself is all that you can do')`, () => {
   it('should create a div with an attribute and text as content', () => {
-    const div = Bouture.div({lang: 'en'}, 'to be yourself is all that you can do').getElement()
+    const div = Bouture.div({lang: 'en'}, 'to be yourself is all that you can do').getElements()
 
     expect(div.getAttribute('lang')).to.equal('en')
     expect(div.textContent).to.equal('to be yourself is all that you can do')
   })
 })
-
+/*
 describe(`Bouture.table.tbody`, () => {
   it('should create a table with one tbody child', () => {
-    const table = Bouture.table.tbody.getElement()
+    const table = Bouture.table.tbody.getElements()
 
     expect(table.parentNode).to.equal(null)
     expect(table.tagName.toLowerString()).to.equal('table')
@@ -223,7 +227,7 @@ describe(`Bouture.table.tbody`, () => {
 
 describe(`Bouture.ul( ['a', 'b', 'c'].map(Bouture.li) )`, () => {
   it('should create a ul with 3 li children with different texts', () => {
-    const ul = Bouture.ul(['a', 'b', 'c'].map(Bouture.li)).getElement()
+    const ul = Bouture.ul(['a', 'b', 'c'].map(Bouture.li)).getElements()
 
     expect(ul.parentNode).to.equal(null)
     expect(ul.tagName.toLowerString()).to.equal('ul')
@@ -233,3 +237,4 @@ describe(`Bouture.ul( ['a', 'b', 'c'].map(Bouture.li) )`, () => {
     expect(ul.children[0].textContent).to.equal('a')
   })
 })
+*/

--- a/test/bouture.test.js
+++ b/test/bouture.test.js
@@ -208,3 +208,28 @@ describe(`Bouture.div({lang: 'en'}, 'to be yourself is all that you can do')`, (
     expect(div.textContent).to.equal('to be yourself is all that you can do')
   })
 })
+
+describe(`Bouture.table.tbody`, () => {
+  it('should create a table with one tbody child', () => {
+    const table = Bouture.table.tbody.getElement()
+
+    expect(table.parentNode).to.equal(null)
+    expect(table.tagName.toLowerString()).to.equal('table')
+
+    expect(table.children.length).to.equal(1)
+    expect(table.children[0].tagName.toLowerString()).to.equal('tbody')
+  })
+})
+
+describe(`Bouture.ul( ['a', 'b', 'c'].map(Bouture.li) )`, () => {
+  it('should create a ul with 3 li children with different texts', () => {
+    const ul = Bouture.ul(['a', 'b', 'c'].map(Bouture.li)).getElement()
+
+    expect(ul.parentNode).to.equal(null)
+    expect(ul.tagName.toLowerString()).to.equal('ul')
+
+    expect(ul.children.length).to.equal(3)
+    expect(ul.children[0].tagName.toLowerString()).to.equal('li')
+    expect(ul.children[0].textContent).to.equal('a')
+  })
+})

--- a/test/bouture.test.js
+++ b/test/bouture.test.js
@@ -13,9 +13,9 @@ describe('Bouture.div', () => {
   })
 })
 
-describe('Bouture.div.getElements()', () => {
+describe('Bouture.div.getElement()', () => {
   it('should return an actual DOM node', () => {
-    const b = Bouture.div.getElements()
+    const b = Bouture.div.getElement()
 
     expect(b).to.be.an.instanceof(HTMLElement)
   })
@@ -25,8 +25,8 @@ describe(`Bouture.div('yo')`, () => {
   it(`should create a div with text 'yo'`, () => {
     const bdiv = Bouture.div('yo')
 
-    expect(bdiv.getElements()).to.be.an.instanceof(HTMLElement)
-    expect(bdiv.getElements().textContent).to.equal('yo')
+    expect(bdiv.getElement()).to.be.an.instanceof(HTMLElement)
+    expect(bdiv.getElement().textContent).to.equal('yo')
   })
 })
 
@@ -34,8 +34,8 @@ describe(`Bouture.div(13)`, () => {
   it(`should create a div with text '13'`, () => {
     const bdiv = Bouture.div(13)
 
-    expect(bdiv.getElements()).to.be.an.instanceof(HTMLElement)
-    expect(bdiv.getElements().textContent).to.equal('13')
+    expect(bdiv.getElement()).to.be.an.instanceof(HTMLElement)
+    expect(bdiv.getElement().textContent).to.equal('13')
   })
 })
 
@@ -43,8 +43,8 @@ describe('Bouture.div(true)', () => {
   it('should create a div with empty string as text', () => {
     const bdiv = Bouture.div(true)
 
-    expect(bdiv.getElements()).to.be.an.instanceof(HTMLElement)
-    expect(bdiv.getElements().textContent).to.equal('')
+    expect(bdiv.getElement()).to.be.an.instanceof(HTMLElement)
+    expect(bdiv.getElement().textContent).to.equal('')
   })
 })
 
@@ -52,8 +52,8 @@ describe(`Bouture.div(NaN)`, () => {
   it(`should create a div with empty string as text`, () => {
     const bdiv = Bouture.div(NaN)
 
-    expect(bdiv.getElements()).to.be.an.instanceof(HTMLElement)
-    expect(bdiv.getElements().textContent).to.equal('')
+    expect(bdiv.getElement()).to.be.an.instanceof(HTMLElement)
+    expect(bdiv.getElement().textContent).to.equal('')
   })
 })
 
@@ -61,8 +61,8 @@ describe(`Bouture.div(undefined)`, () => {
   it(`should create a div with empty string as text`, () => {
     const bdiv = Bouture.div(undefined)
 
-    expect(bdiv.getElements()).to.be.an.instanceof(HTMLElement)
-    expect(bdiv.getElements().textContent).to.equal('')
+    expect(bdiv.getElement()).to.be.an.instanceof(HTMLElement)
+    expect(bdiv.getElement().textContent).to.equal('')
   })
 })
 
@@ -70,8 +70,8 @@ describe(`Bouture.div(null)`, () => {
   it(`should create a div with empty string as text`, () => {
     const bdiv = Bouture.div(null)
 
-    expect(bdiv.getElements()).to.be.an.instanceof(HTMLElement)
-    expect(bdiv.getElements().textContent).to.equal('')
+    expect(bdiv.getElement()).to.be.an.instanceof(HTMLElement)
+    expect(bdiv.getElement().textContent).to.equal('')
   })
 })
 
@@ -79,8 +79,8 @@ describe('Bouture.div(new Symbol())', () => {
   it('should create a div with empty string as text', () => {
     const bdiv = Bouture.div(Symbol('Oï'))
 
-    expect(bdiv.getElements()).to.be.an.instanceof(HTMLElement)
-    expect(bdiv.getElements().textContent).to.equal('')
+    expect(bdiv.getElement()).to.be.an.instanceof(HTMLElement)
+    expect(bdiv.getElement().textContent).to.equal('')
   })
 })
 /*
@@ -88,7 +88,7 @@ describe('Bouture.a', () => {
   it('should create a <a>', () => {
     const a = Bouture.a
 
-    expect(a.getElements()).to.be.an.instanceof(HTMLAnchorElement)
+    expect(a.getElement()).to.be.an.instanceof(HTMLAnchorElement)
   })
 })
 
@@ -96,7 +96,7 @@ describe('Bouture.h1', () => {
   it('should create a <h1>', () => {
     const h1 = Bouture.h1
 
-    expect(h1.getElements()).to.be.an.instanceof(HTMLHeadingElement)
+    expect(h1.getElement()).to.be.an.instanceof(HTMLHeadingElement)
   })
 })
 
@@ -112,7 +112,7 @@ describe('Bouture.div({lang: "fr"})', () => {
   it('should create a div with a lang attribute', () => {
     const bdiv = Bouture.div({lang: 'fr'})
 
-    expect(bdiv.getElements().getAttribute('lang')).to.equal('fr')
+    expect(bdiv.getElement().getAttribute('lang')).to.equal('fr')
   })
 })
 
@@ -120,7 +120,7 @@ describe('Bouture.div({hidden: true})', () => {
   it('should create a div with a hidden attribute set to the empty string', () => {
     const bdiv = Bouture.div({hidden: true})
 
-    expect(bdiv.getElements().getAttribute('hidden')).to.equal('')
+    expect(bdiv.getElement().getAttribute('hidden')).to.equal('')
   })
 })
 
@@ -128,7 +128,7 @@ describe('Bouture.div({hidden: false})', () => {
   it('should create a div with no hidden attribute', () => {
     const bdiv = Bouture.div({hidden: false})
 
-    expect(bdiv.getElements().hasAttribute('hidden')).to.be.false
+    expect(bdiv.getElement().hasAttribute('hidden')).to.be.false
   })
 })
 
@@ -136,7 +136,7 @@ describe('Bouture.div({hidden: undefined})', () => {
   it('should create a div with no hidden attribute', () => {
     const bdiv = Bouture.div({hidden: undefined})
 
-    expect(bdiv.getElements().hasAttribute('hidden')).to.be.false
+    expect(bdiv.getElement().hasAttribute('hidden')).to.be.false
   })
 })
 
@@ -144,7 +144,7 @@ describe('Bouture.div({hidden: null})', () => {
   it('should create a div with no hidden attribute', () => {
     const bdiv = Bouture.div({hidden: null})
 
-    expect(bdiv.getElements().hasAttribute('hidden')).to.be.false
+    expect(bdiv.getElement().hasAttribute('hidden')).to.be.false
   })
 })
 
@@ -152,7 +152,7 @@ describe('Bouture.div({hidden: Symbol()})', () => {
   it('should create a div with no hidden attribute', () => {
     const bdiv = Bouture.div({hidden: Symbol('yo')})
 
-    expect(bdiv.getElements().hasAttribute('hidden')).to.be.false
+    expect(bdiv.getElement().hasAttribute('hidden')).to.be.false
   })
 })
 
@@ -160,7 +160,7 @@ describe('Bouture.input({min: 12})', () => {
   it(`should create an input element with min attribute set to '12'`, () => {
     const bdiv = Bouture.input({min: 12})
 
-    expect(bdiv.getElements().getAttribute('min')).to.equal('12')
+    expect(bdiv.getElement().getAttribute('min')).to.equal('12')
   })
 })
 
@@ -168,7 +168,7 @@ describe('Bouture.input({min: NaN})', () => {
   it(`should create an input element with no min attribute`, () => {
     const bdiv = Bouture.input({min: NaN})
 
-    expect(bdiv.getElements().hasAttribute('min')).to.be.false
+    expect(bdiv.getElement().hasAttribute('min')).to.be.false
   })
 })
 
@@ -176,8 +176,8 @@ describe(`Bouture.div({'data-bloublou': 'yoya'})`, () => {
   it('should create a div with a data attribute', () => {
     const bdiv = Bouture.div({'data-bloublou': 'yoya'})
 
-    expect(bdiv.getElements().getAttribute('data-bloublou')).to.equal('yoya')
-    expect(bdiv.getElements().dataset.bloublou).to.equal('yoya')
+    expect(bdiv.getElement().getAttribute('data-bloublou')).to.equal('yoya')
+    expect(bdiv.getElement().dataset.bloublou).to.equal('yoya')
   })
 })
 
@@ -185,10 +185,10 @@ describe(`Bouture.div({class: ['yo', 'ya']})`, () => {
   it('should create a div with 2 classes', () => {
     const bdiv = Bouture.div({class: ['yo', 'ya']})
 
-    expect(bdiv.getElements().classList.contains('yo')).to.be.true
-    expect(bdiv.getElements().classList.contains('ya')).to.be.true
-    expect(bdiv.getElements().classList.length).to.equal(2)
-    expect(bdiv.getElements().getAttribute('class')).to.equal('yo ya')
+    expect(bdiv.getElement().classList.contains('yo')).to.be.true
+    expect(bdiv.getElement().classList.contains('ya')).to.be.true
+    expect(bdiv.getElement().classList.length).to.equal(2)
+    expect(bdiv.getElement().getAttribute('class')).to.equal('yo ya')
   })
 })
 
@@ -196,23 +196,23 @@ describe(`Bouture.div({class: ['yo', undefined]})`, () => {
   it('should create a div with 1 class', () => {
     const bdiv = Bouture.div({class: ['yo', undefined]})
 
-    expect(bdiv.getElements().classList.contains('yo')).to.be.true
-    expect(bdiv.getElements().classList.length).to.equal(1)
+    expect(bdiv.getElement().classList.contains('yo')).to.be.true
+    expect(bdiv.getElement().classList.length).to.equal(1)
   })
 })
 
 describe(`Bouture.div({lang: 'en'}, 'to be yourself is all that you can do')`, () => {
   it('should create a div with an attribute and text as content', () => {
-    const div = Bouture.div({lang: 'en'}, 'to be yourself is all that you can do').getElements()
+    const div = Bouture.div({lang: 'en'}, 'to be yourself is all that you can do').getElement()
 
     expect(div.getAttribute('lang')).to.equal('en')
     expect(div.textContent).to.equal('to be yourself is all that you can do')
   })
 })
 
-describe(`Bouture.table.tbody`, () => {
+describe(`Bouture.table().tbody()`, () => {
   it('should create a table with one tbody child', () => {
-    const table = Bouture.table().tbody().getElements()
+    const table = Bouture.table().tbody().getElement()
 
     expect(table.parentNode).to.equal(null)
     expect(table.tagName.toLowerCase()).to.equal('table')
@@ -222,10 +222,29 @@ describe(`Bouture.table.tbody`, () => {
   })
 })
 
+describe(`Bouture.div().a(); Bouture.h1(); Bouture.div().div('').a('{href: 'http://bouture.com'}')`, () => {
+  it('should create several Bouture and retrieve our children', () => {
+    const divA = Bouture.div().p()
+    const h1 = Bouture.h1()
+    const divDivA = Bouture.div().div('').a(`{href: 'http://bouture.com'}`)
+
+    expect(divA.getElement().tagName.toLowerCase()).to.equal('div')
+    expect(h1.getElement().tagName.toLowerCase()).to.equal('h1')
+    expect(divDivA.getElement().tagName.toLowerCase()).to.equal('div')
+
+    expect(divA.getElement().children.length).to.equal(1)
+    expect(h1.getElement().children.length).to.equal(1)
+    expect(divDivA.getElement().children.length).to.equal(2)
+
+    expect(divA.getElement().children[0].tagName.toLowerCase()).to.equal('p')
+    expect(divDivA.getElement().children[1].tagName.toLowerCase()).to.equal('a')
+  })
+})
+
 /*
 describe(`Bouture.table.tbody`, () => {
   it('should create a table with one tbody child', () => {
-    const table = Bouture.table.tbody.getElements()
+    const table = Bouture.table.tbody.getElement()
 
     expect(table.parentNode).to.equal(null)
     expect(table.tagName.toLowerCase()).to.equal('table')
@@ -237,7 +256,7 @@ describe(`Bouture.table.tbody`, () => {
 
 describe(`Bouture.ul( ['a', 'b', 'c'].map(Bouture.li) )`, () => {
   it('should create a ul with 3 li children with different texts', () => {
-    const ul = Bouture.ul(['a', 'b', 'c'].map(Bouture.li)).getElements()
+    const ul = Bouture.ul(['a', 'b', 'c'].map(Bouture.li)).getElement()
 
     expect(ul.parentNode).to.equal(null)
     expect(ul.tagName.toLowerString()).to.equal('ul')

--- a/test/bouture.test.js
+++ b/test/bouture.test.js
@@ -224,19 +224,19 @@ describe(`Bouture.table().tbody()`, () => {
 
 describe(`Bouture.div().a(); Bouture.h1(); Bouture.div().div('').a('{href: 'http://bouture.com'}')`, () => {
   it('should create several Bouture and retrieve our children', () => {
-    const divA = Bouture.div().p()
+    const divP = Bouture.div().p()
     const h1 = Bouture.h1()
     const divDivA = Bouture.div().div('').a(`{href: 'http://bouture.com'}`)
 
-    expect(divA.getElement().tagName.toLowerCase()).to.equal('div')
+    expect(divP.getElement().tagName.toLowerCase()).to.equal('div')
     expect(h1.getElement().tagName.toLowerCase()).to.equal('h1')
     expect(divDivA.getElement().tagName.toLowerCase()).to.equal('div')
 
-    expect(divA.getElement().children.length).to.equal(1)
-    expect(h1.getElement().children.length).to.equal(1)
-    expect(divDivA.getElement().children.length).to.equal(2)
+    expect(divP.getElement().children.length).to.equal(1)
+    expect(h1.getElement().children.length).to.equal(0)
+    expect(divDivA.getElement().children.length).to.equal(1)
 
-    expect(divA.getElement().children[0].tagName.toLowerCase()).to.equal('p')
+    expect(divP.getElement().children[0].tagName.toLowerCase()).to.equal('p')
     expect(divDivA.getElement().children[1].tagName.toLowerCase()).to.equal('a')
   })
 })

--- a/test/bouture.test.js
+++ b/test/bouture.test.js
@@ -1,9 +1,6 @@
 import {expect} from 'chai'
 import Bouture from '../bouture.js'
 
-const bdiv = Bouture.div('yo')
-console.log('Bouture', bdiv.getElements())
-
 /*
 describe('Bouture.div', () => {
   it('should create an object', () => {

--- a/test/bouture.test.js
+++ b/test/bouture.test.js
@@ -1,6 +1,8 @@
 import {expect} from 'chai'
 import Bouture from '../bouture.js'
 
+console.log(Bouture.div('test').a('bloop'))
+
 /*
 describe('Bouture.div', () => {
   it('should create an object', () => {

--- a/test/bouture.test.js
+++ b/test/bouture.test.js
@@ -1,8 +1,6 @@
 import {expect} from 'chai'
 import Bouture from '../bouture.js'
 
-console.log(Bouture.div('test').a('bloop'))
-
 /*
 describe('Bouture.div', () => {
   it('should create an object', () => {
@@ -211,13 +209,26 @@ describe(`Bouture.div({lang: 'en'}, 'to be yourself is all that you can do')`, (
     expect(div.textContent).to.equal('to be yourself is all that you can do')
   })
 })
+
+describe(`Bouture.table.tbody`, () => {
+  it('should create a table with one tbody child', () => {
+    const table = Bouture.table().tbody().getElements()
+
+    expect(table.parentNode).to.equal(null)
+    expect(table.tagName.toLowerCase()).to.equal('table')
+
+    expect(table.children.length).to.equal(1)
+    expect(table.children[0].tagName.toLowerCase()).to.equal('tbody')
+  })
+})
+
 /*
 describe(`Bouture.table.tbody`, () => {
   it('should create a table with one tbody child', () => {
     const table = Bouture.table.tbody.getElements()
 
     expect(table.parentNode).to.equal(null)
-    expect(table.tagName.toLowerString()).to.equal('table')
+    expect(table.tagName.toLowerCase()).to.equal('table')
 
     expect(table.children.length).to.equal(1)
     expect(table.children[0].tagName.toLowerString()).to.equal('tbody')


### PR DESCRIPTION
(Replacing #14)

- [ ] Must enable creating an element with a child with a nested syntax (`Bouture.table.tbody.tr`)
- [ ] Must enable creating an element with a single child passed as an argument in an array